### PR TITLE
Add internal Frame and Stack implementations to aid implementation of Logger.WithStack()

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,2 @@
+// Package internal provides helpers for concrete slog implementations
+package internal

--- a/internal/stack.go
+++ b/internal/stack.go
@@ -1,0 +1,147 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Frame represents a function call on the call Stack.
+// This implementation is heavily based on
+// github.com/pkg/errors.Frame but all parts are resolved
+// immediatelly for later consumption.
+type Frame struct {
+	pc    uintptr
+	entry uintptr
+	name  string
+	file  string
+	line  int
+}
+
+func frameForPC(pc uintptr) Frame {
+	var entry uintptr
+	var name string
+	var file string
+	var line int
+
+	if fp := runtime.FuncForPC(pc - 1); fp != nil {
+		entry = fp.Entry()
+		name = fp.Name()
+		file, line = fp.FileLine(pc)
+	} else {
+		name = "unknown"
+		file = "unknown"
+	}
+
+	return Frame{
+		pc:    pc,
+		entry: entry,
+		name:  name,
+		file:  file,
+		line:  line,
+	}
+}
+
+// Name returns the name of the function.
+func (f Frame) Name() string {
+	return f.name
+}
+
+// File returns the file name of the source code
+// corresponding to this Frame
+func (f Frame) File() string {
+	return f.file
+}
+
+// Line returns the file number on the source code
+// corresponding to this Frame, or zero if unknown.
+func (f Frame) Line() int {
+	return f.line
+}
+
+// FileLine returns File name and Line separated by
+// a colon, or only the filename if the Line isn't known
+func (f Frame) FileLine() string {
+	if f.line > 0 {
+		return fmt.Sprintf("%s:%v", f.file, f.line)
+	}
+
+	return f.file
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//	%s    source file
+//	%d    source line
+//	%n    function name
+//	%v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//	%+s   function name and path of source file relative to the compile time
+//	      GOPATH separated by \n\t (<funcname>\n\t<path>)
+//	%+n   full package name followed by function name
+//	%+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			io.WriteString(s, f.name)
+			io.WriteString(s, "\n\t")
+			io.WriteString(s, f.file)
+		default:
+			io.WriteString(s, path.Base(f.file))
+		}
+	case 'd':
+		io.WriteString(s, strconv.Itoa(f.line))
+	case 'n':
+		n := f.name
+		switch {
+		case s.Flag('+'):
+			io.WriteString(s, n)
+		default:
+			io.WriteString(s, funcname(n))
+		}
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// Stack is an snapshot of the call stack in
+// the form of an array of Frames.
+type Stack []Frame
+
+// Format formats the stack of Frames following the rules
+// explained in Frame.Format with the adition of the '#' flag.
+//
+// when '#' is passed, like for example %#+v each row
+// will be prefixed by [i/n] indicating the position in the stack
+// followed by the %+v representation of the Frame
+func (st Stack) Format(s fmt.State, verb rune) {
+
+	if s.Flag('#') {
+		l := len(st)
+		for i, f := range st {
+			fmt.Fprintf(s, "\n[%v/%v] ", i, l)
+			f.Format(s, verb)
+		}
+	} else {
+		for _, f := range st {
+			io.WriteString(s, "\n")
+			f.Format(s, verb)
+		}
+	}
+}
+
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}


### PR DESCRIPTION
This is a work I had done on go.sancus.dev/core/errors, heavily based on github.com/pkg/errors.Frame, with the key difference being that all frames are already resolved instead of just carrying around a PC
