### PR TITLE
Add initial channel based logger (cblog) inspired by gnocco

### DIFF
--- a/cblog/cblog.go
+++ b/cblog/cblog.go
@@ -1,0 +1,166 @@
+// Package cblog provides a channel based logger
+package cblog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/darvaza-proxy/slog"
+	"github.com/darvaza-proxy/slog/internal"
+)
+
+const (
+	// DefaultOutputBufferSize is the default size of the channel buffer used for logging.
+	DefaultOutputBufferSize = 1024
+)
+
+var (
+	_ slog.Logger = (*Logger)(nil)
+)
+
+// LogMsg represents one structured log entry
+type LogMsg struct {
+	Message string
+	Level   slog.LogLevel
+	Fields  map[string]any
+	Stack   internal.Stack
+}
+
+// Logger is a slog.Logger using a channel as backend
+type Logger struct {
+	internal.Loglet
+
+	l *cblog
+}
+
+type cblog struct {
+	ch chan LogMsg
+
+	Logger
+}
+
+// Print adds a log entry with arguments handled in the manner of fmt.Print
+func (l *Logger) Print(args ...any) {
+	l.sendMsg(fmt.Sprint(args...))
+}
+
+// Println adds a log entry with arguments handled in the manner of fmt.Println
+func (l *Logger) Println(args ...any) {
+	l.sendMsg(fmt.Sprintln(args...))
+}
+
+// Printf adds a log entry with arguments handled in the manner of fmt.Printf
+func (l *Logger) Printf(format string, args ...any) {
+	l.sendMsg(fmt.Sprintf(format, args...))
+}
+
+func (l *Logger) sendMsg(msg string) {
+	var m map[string]any
+
+	if n := l.FieldsCount(); n > 0 {
+		iter := l.Fields()
+
+		m = make(map[string]any, n)
+
+		for iter.Next() {
+			k, v := iter.Field()
+
+			m[k] = v
+		}
+
+	}
+
+	l.l.ch <- LogMsg{
+		Message: strings.TrimSpace(msg),
+		Level:   l.Level(),
+		Fields:  m,
+		Stack:   l.Stack(),
+	}
+}
+
+// Debug returns a new logger set to add entries as level Debug
+func (l *Logger) Debug() slog.Logger {
+	return l.WithLevel(slog.Debug)
+}
+
+// Info returns a new logger set to add entries as level Info
+func (l *Logger) Info() slog.Logger {
+	return l.WithLevel(slog.Info)
+}
+
+// Warn returns a new logger set to add entries as level Warn
+func (l *Logger) Warn() slog.Logger {
+	return l.WithLevel(slog.Warn)
+}
+
+// Error returns a new logger set to add entries as level Error
+func (l *Logger) Error() slog.Logger {
+	return l.WithLevel(slog.Error)
+}
+
+// Fatal returns a new logger set to add entries as level Fatal
+func (l *Logger) Fatal() slog.Logger {
+	return l.WithLevel(slog.Fatal)
+}
+
+// WithLevel returns a new logger set to add entries to the specified level
+func (l *Logger) WithLevel(level slog.LogLevel) slog.Logger {
+	if level == l.Level() {
+		return l
+	}
+
+	out := &Logger{
+		Loglet: l.Loglet.WithLevel(level),
+		l:      l.l,
+	}
+	return out
+}
+
+// WithStack attaches a call stack to a new logger
+func (l *Logger) WithStack(skip int) slog.Logger {
+	out := &Logger{
+		Loglet: l.Loglet.WithStack(skip + 1),
+		l:      l.l,
+	}
+	return out
+}
+
+// WithField returns a new logger with a field attached
+func (l *Logger) WithField(label string, value any) slog.Logger {
+	out := &Logger{
+		Loglet: l.Loglet.WithField(label, value),
+		l:      l.l,
+	}
+	return out
+}
+
+// WithFields returns a new logger with a set of fields attached
+func (l *Logger) WithFields(fields map[string]any) slog.Logger {
+	if len(fields) == 0 {
+		return l
+	}
+
+	out := &Logger{
+		Loglet: l.Loglet.WithFields(fields),
+		l:      l.l,
+	}
+	return out
+}
+
+// New creates a new Channel Based Logger
+func New(ch chan LogMsg) (*Logger, <-chan LogMsg) {
+	if ch == nil {
+		ch = make(chan LogMsg, DefaultOutputBufferSize)
+	}
+
+	l := newLogger(ch)
+	return &l.Logger, ch
+}
+
+func newLogger(ch chan LogMsg) *cblog {
+	l := &cblog{
+		ch: ch,
+	}
+	l.Logger.l = l
+	return l
+}

--- a/cblog/go.mod
+++ b/cblog/go.mod
@@ -1,0 +1,7 @@
+module github.com/darvaza-proxy/slog/cblog
+
+go 1.19
+
+replace github.com/darvaza-proxy/slog => ../
+
+require github.com/darvaza-proxy/slog v0.0.0-20230102194403-372027bb9066

--- a/internal/loglet.go
+++ b/internal/loglet.go
@@ -1,0 +1,143 @@
+package internal
+
+import "github.com/darvaza-proxy/slog"
+
+// Loglet represents a link on the Logger context chain
+type Loglet struct {
+	parent *Loglet
+	level  slog.LogLevel
+	keys   []string
+	values []any
+	stack  Stack
+}
+
+// Level returns the LogLevel of a Loglet
+func (ll *Loglet) Level() slog.LogLevel {
+	return ll.level
+}
+
+// WithLevel sets the LogLevel for a new Loglet
+func (ll *Loglet) WithLevel(level slog.LogLevel) Loglet {
+	if level == ll.level {
+		return *ll
+	}
+
+	return Loglet{
+		parent: ll,
+		level:  level,
+		stack:  ll.stack,
+	}
+}
+
+// Stack returns the callstack associated to a Loglet
+func (ll *Loglet) Stack() Stack {
+	return ll.stack
+}
+
+// WithStack attaches a call stack to a new Loglet
+func (ll *Loglet) WithStack(skip int) Loglet {
+	return Loglet{
+		parent: ll,
+		level:  ll.level,
+		stack:  StackTrace(skip + 1),
+	}
+}
+
+// WithField attaches a field to a new Loglet
+func (ll *Loglet) WithField(label string, value any) Loglet {
+	return Loglet{
+		parent: ll,
+		level:  ll.level,
+		stack:  ll.stack,
+		keys:   []string{label},
+		values: []any{value},
+	}
+}
+
+// WithFields attaches a set of fields to a new Loglet
+func (ll *Loglet) WithFields(fields map[string]any) Loglet {
+	if n := len(fields); n > 0 {
+		keys := make([]string, n)
+		values := make([]any, n)
+
+		i := 0
+		for k, v := range fields {
+			keys[i] = k
+			values[i] = v
+			i++
+		}
+
+		return Loglet{
+			parent: ll,
+			level:  ll.level,
+			stack:  ll.stack,
+			keys:   keys[:i],
+			values: values[:i],
+		}
+	}
+	return *ll
+}
+
+// FieldsCount return the number of fields on a Log context
+func (ll *Loglet) FieldsCount() int {
+	count := 0
+	for ll != nil {
+		count += len(ll.keys)
+		ll = ll.parent
+	}
+	return count
+}
+
+// Fields returns a FieldsIterator
+func (ll *Loglet) Fields() (iter *FieldsIterator) {
+	return &FieldsIterator{
+		ll: ll,
+		i:  0,
+	}
+}
+
+// FieldsIterator iterates over fields on a Log context
+type FieldsIterator struct {
+	ll *Loglet
+	i  int
+	k  string
+	v  any
+}
+
+// Next advances iterator to next value. it returns false to indicate
+// end of iteration, or true when the next (or first) field
+// is ready to be accessed using Key(), Value(), or Field()
+// when there are no new ones
+func (iter *FieldsIterator) Next() bool {
+
+	for iter.ll != nil {
+		ll := iter.ll
+
+		if i := iter.i; i < len(ll.keys) {
+			iter.k = ll.keys[i]
+			iter.v = ll.values[i]
+			iter.i = i + 1
+			return true
+		}
+
+		// up
+		iter.ll = iter.ll.parent
+		iter.i = 0
+	}
+	return false
+}
+
+// Key returns the label of the current field
+func (iter *FieldsIterator) Key() string {
+	return iter.k
+}
+
+// Value returns the value of the current field
+func (iter *FieldsIterator) Value() any {
+	return iter.v
+}
+
+// Field returns key and value of the current field
+func (iter *FieldsIterator) Field() (key string, value any) {
+	return iter.k, iter.v
+}


### PR DESCRIPTION
This adds the initial implementation of `slog/cblog`. `New()` returns a LogMsg channel of buffer size 1024 by default as it was in gnocco.

`NewWithCallback()` is been postponed until we have a good discussion about how to deal with the worker's cancellation.