### PR TITLE
vscode: add workspace to make gopls capable of handling the monorepo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.exclude": {
+        "logrus": true,
+        "zap": true,
+        "zerolog": true,
+        "cblog": true
+    }
+}

--- a/slog.code-workspace
+++ b/slog.code-workspace
@@ -1,0 +1,19 @@
+{
+	"folders": [
+		{
+			"path": "logrus"
+		},
+		{
+			"path": "zap"
+		},
+		{
+			"path": "zerolog"
+		},
+		{
+			"path": "cblog"
+		},
+		{
+			"path": "."
+		},
+	]
+}


### PR DESCRIPTION
gopls can't handle `go.mod` in subdirectories so we have to ignore them from the top level and then add them as additional folders