### PR TITLE
tools/gen_mk.sh: fix handling of non-slog replace entries in go.mod

### DIFF
--- a/tools/gen_mk.sh
+++ b/tools/gen_mk.sh
@@ -96,7 +96,7 @@ EOT
 		fi
 
 		if $sequential; then
-			deps="$(sed -n -e 's|^.*=> \.\?\./\([^/]\+\).*$|\1|p' "$x/go.mod" | tr '\n' ' ')"
+			deps="$(sed -n -e 's|^.*=> \.\?\./\([^/]\+\).*$|\1|p' "$x/go.mod" | grep -v "^\.\.$" | tr '\n' ' ')"
 		else
 			deps=
 		fi


### PR DESCRIPTION
non-slog replacements will have ".." as second segment