### PR TITLE
build-sys: simplify dependency generator

### DIFF
--- a/tools/gen_mk.sh
+++ b/tools/gen_mk.sh
@@ -95,10 +95,9 @@ EOT
 			esac
 		fi
 
+		deps=
 		if $sequential; then
-			deps="$(sed -n -e 's|^.*=> \.\?\./\([^/]\+\).*$|\1|p' "$x/go.mod" | tr '\n' ' ')"
-		else
-			deps=
+			[ "$k" = root ] || deps=root
 		fi
 
 		cat <<EOT


### PR DESCRIPTION
all our subprojects depend on root and never between each other

this necessarily complex expression was getting confused by `replace` rules to third-party repos
