### PR TITLE
slog: change LogLevel type to int8

### DIFF
--- a/slog.go
+++ b/slog.go
@@ -2,7 +2,7 @@
 package slog
 
 // LogLevel represents the level of criticality of a log entry
-type LogLevel uint
+type LogLevel int8
 
 const (
 	// UndefinedLevel is a placeholder for the zero-value when no level has been set


### PR DESCRIPTION
Several backends use negative indexes for LogLevel so uint is not really fitting, int8 is more than
enough to store the levels

Signed-off-by: Nagy Károly Gábriel <k@jpi.io>