### PR TITLE
zap: add Unwrap() to export the underlying structures

### DIFF
--- a/handlers/zap/zap.go
+++ b/handlers/zap/zap.go
@@ -22,6 +22,11 @@ type Logger struct {
 	config *zap.Config
 }
 
+// Unwrap returns the underlying zap logger
+func (zpl *Logger) Unwrap() (*zap.Logger, *zap.Config) {
+	return zpl.logger, zpl.config
+}
+
 // Enabled tells this logger is enabled
 func (zpl *Logger) Enabled() bool {
 	if zpl == nil || zpl.logger == nil || zpl.logger.Level() == zapcore.InvalidLevel {


### PR DESCRIPTION
to be used when convering an slog.Logger to a zap.Logger