### PR TITLE
renovate: prevent Go updates beyond the current 1.21

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "1.21"
+    }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced configuration for dependency management, including specific rules for Go programming language versions.
- **Chores**
	- Updated the Renovate bot configuration to improve version control for Go dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->