### PR TITLE
chore(deps): update handlers to darvaza.org/slog@v0.15.5

### DIFF
--- a/handlers/cblog/go.mod
+++ b/handlers/cblog/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.15.6
-	darvaza.org/slog v0.5.14
+	darvaza.org/slog v0.5.15
 )
 
 require (

--- a/handlers/discard/go.mod
+++ b/handlers/discard/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 replace darvaza.org/slog => ../../
 
-require darvaza.org/slog v0.5.14
+require darvaza.org/slog v0.5.15
 
 require (
 	darvaza.org/core v0.15.6 // indirect

--- a/handlers/filter/go.mod
+++ b/handlers/filter/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.15.6
-	darvaza.org/slog v0.5.14
+	darvaza.org/slog v0.5.15
 )
 
 require (

--- a/handlers/logrus/go.mod
+++ b/handlers/logrus/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.15.6
-	darvaza.org/slog v0.5.14
+	darvaza.org/slog v0.5.15
 	github.com/sirupsen/logrus v1.9.3
 )
 

--- a/handlers/zap/go.mod
+++ b/handlers/zap/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.15.6
-	darvaza.org/slog v0.5.14
+	darvaza.org/slog v0.5.15
 	go.uber.org/zap v1.27.0
 )
 

--- a/handlers/zerolog/go.mod
+++ b/handlers/zerolog/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.15.6
-	darvaza.org/slog v0.5.14
+	darvaza.org/slog v0.5.15
 	github.com/rs/zerolog v1.33.0
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `darvaza.org/slog` module to version `v0.5.15` across multiple handler modules:
		- `cblog`
		- `discard`
		- `filter`
		- `logrus`
		- `zap`
		- `zerolog`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->