### PR TITLE
build: update all handlers to slog v0.7.1

### DIFF
--- a/handlers/cblog/go.mod
+++ b/handlers/cblog/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.17.1
-	darvaza.org/slog v0.7.0
+	darvaza.org/slog v0.7.1
 )
 
 require (

--- a/handlers/discard/go.mod
+++ b/handlers/discard/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.17.1 // indirect
-	darvaza.org/slog v0.7.0
+	darvaza.org/slog v0.7.1
 )
 
 require (

--- a/handlers/filter/go.mod
+++ b/handlers/filter/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.17.1
-	darvaza.org/slog v0.7.0
+	darvaza.org/slog v0.7.1
 )
 
 require (

--- a/handlers/logrus/go.mod
+++ b/handlers/logrus/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.17.1
-	darvaza.org/slog v0.7.0
+	darvaza.org/slog v0.7.1
 )
 
 require github.com/sirupsen/logrus v1.9.3

--- a/handlers/zap/go.mod
+++ b/handlers/zap/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.17.1 // indirect
-	darvaza.org/slog v0.7.0
+	darvaza.org/slog v0.7.1
 )
 
 require go.uber.org/zap v1.27.0

--- a/handlers/zerolog/go.mod
+++ b/handlers/zerolog/go.mod
@@ -6,7 +6,7 @@ replace darvaza.org/slog => ../../
 
 require (
 	darvaza.org/core v0.17.1
-	darvaza.org/slog v0.7.0
+	darvaza.org/slog v0.7.1
 )
 
 require github.com/rs/zerolog v1.34.0


### PR DESCRIPTION
Update all handler modules to use darvaza.org/slog v0.7.1

This PR updates the slog dependency in all handler modules following the release of v0.7.1.

## Changes
- Update cblog handler to slog v0.7.1
- Update discard handler to slog v0.7.1
- Update filter handler to slog v0.7.1
- Update logrus handler to slog v0.7.1
- Update zap handler to slog v0.7.1
- Update zerolog handler to slog v0.7.1

All handlers have been tested and build successfully with the new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer version across multiple components to ensure consistency and maintain up-to-date libraries. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->