### PR TITLE
feat(testing): add TestBidirectionalWithOptions for v0.7.3

### DIFF
--- a/internal/testing/README.md
+++ b/internal/testing/README.md
@@ -126,6 +126,27 @@ func TestMyBidirectionalAdapter(t *testing.T) {
 }
 ```
 
+For adapters with known limitations (e.g., missing log levels):
+
+```go
+func TestAdapterWithLimitations(t *testing.T) {
+    factory := func(backend slog.Logger) slog.Logger {
+        // Adapter that doesn't support Warn level
+        return limitedadapter.New(backend)
+    }
+
+    // Define expected level mappings
+    opts := &slogtest.BidirectionalTestOptions{
+        LevelExceptions: map[slog.LogLevel]slog.LogLevel{
+            slog.Warn: slog.Info, // Warn gets mapped to Info
+        },
+    }
+
+    // Test with options to handle known limitations
+    slogtest.TestBidirectionalWithOptions(t, "LimitedAdapter", factory, opts)
+}
+```
+
 ## API Reference
 
 ### Test Logger
@@ -165,6 +186,11 @@ func TestMyBidirectionalAdapter(t *testing.T) {
   - `fn` should return a logger that uses the given logger as backend
   - Tests message preservation, field handling, and level mapping
   - Verifies round-trip conversion maintains data integrity
+
+- `TestBidirectionalWithOptions(t, name, fn, opts)` - Tests with level mapping exceptions
+  - Handles adapters with known limitations (e.g., missing log levels)
+  - `opts.LevelExceptions` maps expected level transformations
+  - Useful for adapters like logr that don't support all slog levels
 
 ## Design Principles
 

--- a/internal/testing/bidirectional_test.go
+++ b/internal/testing/bidirectional_test.go
@@ -1,0 +1,155 @@
+package testing
+
+import (
+	"testing"
+
+	"darvaza.org/slog"
+)
+
+// TestBidirectionalOptions verifies that BidirectionalTestOptions works correctly
+func TestBidirectionalOptions(t *testing.T) {
+	t.Run("NilOptions", testNilOptions)
+	t.Run("WithExceptions", testWithExceptions)
+	t.Run("EmptyExceptions", testEmptyExceptions)
+}
+
+func testNilOptions(t *testing.T) {
+	t.Helper()
+	var opts *BidirectionalTestOptions
+
+	// All levels should map to themselves with nil options
+	levels := []slog.LogLevel{
+		slog.Debug, slog.Info, slog.Warn, slog.Error, slog.Fatal, slog.Panic,
+	}
+
+	for _, level := range levels {
+		if got := opts.ExpectedLevel(level); got != level {
+			t.Errorf("ExpectedLevel(%v) = %v, want %v", level, got, level)
+		}
+	}
+}
+
+func testWithExceptions(t *testing.T) {
+	t.Helper()
+	opts := &BidirectionalTestOptions{
+		LevelExceptions: map[slog.LogLevel]slog.LogLevel{
+			slog.Warn:  slog.Info, // adapter limitation mapping
+			slog.Debug: slog.Info, // no debug support
+		},
+	}
+
+	// Test mapped levels
+	if got := opts.ExpectedLevel(slog.Warn); got != slog.Info {
+		t.Errorf("ExpectedLevel(Warn) = %v, want Info", got)
+	}
+	if got := opts.ExpectedLevel(slog.Debug); got != slog.Info {
+		t.Errorf("ExpectedLevel(Debug) = %v, want Info", got)
+	}
+
+	// Test unmapped levels remain unchanged
+	if got := opts.ExpectedLevel(slog.Error); got != slog.Error {
+		t.Errorf("ExpectedLevel(Error) = %v, want Error", got)
+	}
+	if got := opts.ExpectedLevel(slog.Info); got != slog.Info {
+		t.Errorf("ExpectedLevel(Info) = %v, want Info", got)
+	}
+}
+
+func testEmptyExceptions(t *testing.T) {
+	t.Helper()
+	opts := &BidirectionalTestOptions{
+		LevelExceptions: map[slog.LogLevel]slog.LogLevel{},
+	}
+
+	// All levels should map to themselves with empty map
+	if got := opts.ExpectedLevel(slog.Warn); got != slog.Warn {
+		t.Errorf("ExpectedLevel(Warn) = %v, want Warn", got)
+	}
+}
+
+// TestBidirectionalWithOptionsIntegration tests the integration with a mock adapter
+func TestBidirectionalWithOptionsIntegration(t *testing.T) {
+	// Create a mock adapter that changes Warn to Info
+	mockAdapter := func(backend slog.Logger) slog.Logger {
+		return &levelMappingLogger{
+			backend: backend,
+			mapping: map[slog.LogLevel]slog.LogLevel{
+				slog.Warn: slog.Info,
+			},
+		}
+	}
+
+	// This should pass with the correct options
+	opts := &BidirectionalTestOptions{
+		LevelExceptions: map[slog.LogLevel]slog.LogLevel{
+			slog.Warn: slog.Info,
+		},
+	}
+
+	TestBidirectionalWithOptions(t, "MockAdapter", mockAdapter, opts)
+}
+
+// levelMappingLogger is a test logger that maps levels
+type levelMappingLogger struct {
+	backend slog.Logger
+	mapping map[slog.LogLevel]slog.LogLevel
+}
+
+func (l *levelMappingLogger) mapLevel(level slog.LogLevel) slog.LogLevel {
+	if mapped, ok := l.mapping[level]; ok {
+		return mapped
+	}
+	return level
+}
+
+func (l *levelMappingLogger) Debug() slog.Logger { return l.WithLevel(slog.Debug) }
+func (l *levelMappingLogger) Info() slog.Logger  { return l.WithLevel(slog.Info) }
+func (l *levelMappingLogger) Warn() slog.Logger  { return l.WithLevel(slog.Warn) }
+func (l *levelMappingLogger) Error() slog.Logger { return l.WithLevel(slog.Error) }
+func (l *levelMappingLogger) Fatal() slog.Logger { return l.WithLevel(slog.Fatal) }
+func (l *levelMappingLogger) Panic() slog.Logger { return l.WithLevel(slog.Panic) }
+
+func (l *levelMappingLogger) WithLevel(level slog.LogLevel) slog.Logger {
+	return l.backend.WithLevel(l.mapLevel(level))
+}
+
+func (l *levelMappingLogger) WithStack(skip int) slog.Logger {
+	return &levelMappingLogger{
+		backend: l.backend.WithStack(skip),
+		mapping: l.mapping,
+	}
+}
+
+func (l *levelMappingLogger) WithField(key string, value any) slog.Logger {
+	return &levelMappingLogger{
+		backend: l.backend.WithField(key, value),
+		mapping: l.mapping,
+	}
+}
+
+func (l *levelMappingLogger) WithFields(fields map[string]any) slog.Logger {
+	return &levelMappingLogger{
+		backend: l.backend.WithFields(fields),
+		mapping: l.mapping,
+	}
+}
+
+func (l *levelMappingLogger) Enabled() bool {
+	return l.backend.Enabled()
+}
+
+func (l *levelMappingLogger) WithEnabled() (slog.Logger, bool) {
+	return l, l.Enabled()
+}
+
+func (l *levelMappingLogger) Print(args ...any) {
+	l.backend.Print(args...)
+}
+
+func (l *levelMappingLogger) Println(args ...any) {
+	l.backend.Println(args...)
+}
+
+func (l *levelMappingLogger) Printf(format string, args ...any) {
+	l.backend.Printf(format, args...)
+}


### PR DESCRIPTION
## Summary

- Add `BidirectionalTestOptions` struct with `LevelExceptions` map for handling adapters with level mapping limitations
- Implement `TestBidirectionalWithOptions` function to test adapters that cannot preserve all log levels
- Add `ExpectedLevel` method that gracefully handles nil options

This feature is particularly useful for the logr adapter which doesn't have a native Warn level and maps it to Info.

## Test plan

- [x] Tests pass for the new implementation
- [x] Documentation updated in internal/testing/README.md
- [x] Linting passes with `make tidy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal testing documentation with guidance and examples for testing adapters that do not support all log levels, including new options for level mapping in bidirectional tests.

* **New Features**
  * Introduced customizable options for bidirectional adapter tests, allowing mapping of unsupported log levels to supported ones.
  * Added new test function to support these options and handle level mapping exceptions.

* **Tests**
  * Added comprehensive unit and integration tests to verify correct behavior of log level mapping in bidirectional tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->