### PR TITLE
fix(build): enhance monorepo coverage with proper codecov integration and documentation

### DIFF
--- a/internal/build/make_codecov.sh
+++ b/internal/build/make_codecov.sh
@@ -152,15 +152,14 @@ EOF
 
 echo "::group::Upload coverage for $name"
 if [ -s "$file" ]; then
-	"\$CODECOV_BIN" upload-process \\
+	"\$CODECOV_BIN" --codecov-yml-path "\${SCRIPT_DIR}/codecov.yml" upload-process \\
 		--disable-search \\
+		--fail-on-error \\
 		--file "$file" \\
-		--flag "$name" \\
-		--codecov-yml-path "\${SCRIPT_DIR}/codecov.yml" || {
-		echo "Warning: Failed to upload coverage for $name"
-	}
+		--flag "$name"
 else
-	echo "Warning: Coverage file not found for $name"
+	echo "Error: Coverage file not found for $name" >&2
+	exit 1
 fi
 echo "::endgroup::"
 EOF


### PR DESCRIPTION
## Summary

This PR enhances the monorepo coverage system with per-module tracking, proper Codecov integration, and comprehensive documentation.

Key improvements:
- Split coverage collection from Codecov configuration generation
- Add progress indicators showing module names and coverage percentages
- Generate codecov.yml with per-module flags and thresholds
- Fix codecov CLI integration with correct --codecov-yml-path syntax
- Document design decisions and best practices for monorepo coverage

## Changes

1. **Coverage collection** (`make_coverage.sh`):
   - Shows progress with module name and coverage percentage
   - Handles binary test output with `grep -a`
   - Generates individual .prof files per module
   - Merges into coverage.out for local viewing

2. **Codecov integration** (`make_codecov.sh`):
   - Generates codecov.yml with flags and path mappings
   - Creates codecov.sh upload script with:
     - SHA256 integrity verification for codecov CLI
     - Proper error handling (fails on any upload error)
     - Correct CLI syntax for custom config path

3. **Documentation** (`README-coverage.md`):
   - Explains why separate uploads are used per module
   - Documents design decisions and flag attribution strategy
   - Adds troubleshooting guide for common issues
   - Clarifies performance considerations

4. **Workflow updates**:
   - New make targets: `coverage` (local) and `codecov` (CI)
   - GitHub workflow executes generated codecov.sh script

## Test plan

- [x] Run `make coverage` locally - shows progress indicators
- [x] Run `make codecov` locally - generates proper files
- [x] Verify codecov.yml has flags for all modules
- [x] Verify codecov.sh uses correct CLI syntax
- [x] CI uploads coverage with proper flags
- [x] Documentation clearly explains the implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and reporting in the Codecov upload process to provide clearer messages and stricter failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->