### PR TITLE
docs(RELEASE): update latest releases to September 2025

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -356,18 +356,19 @@ For future automation:
 
 ## Latest Releases
 
-As of August 2025:
+### As of September 2025
 
-- **slog**: v0.7.7 (Go 1.23 required)
-- **handlers/cblog**: v0.8.0
-- **handlers/discard**: v0.6.1
-- **handlers/filter**: v0.6.1
-- **handlers/logr**: v0.1.0
-- **handlers/logrus**: v0.7.2
-- **handlers/zap**: v0.7.0
-- **handlers/zerolog**: v0.6.1
+- **slog**: v0.8.1 (Go 1.23 or later required).
+- **handlers/cblog**: v0.8.1.
+- **handlers/discard**: v0.6.2.
+- **handlers/filter**: v0.7.0.
+  - Breaking changes; see handlers/filter/README.md.
+- **handlers/logr**: v0.1.1.
+- **handlers/logrus**: v0.7.3.
+- **handlers/zap**: v0.7.1.
+- **handlers/zerolog**: v0.6.2.
 
-All modules require Go 1.23 or later and use darvaza.org/core v0.18.1.
+All modules require Go 1.23 or later and use darvaza.org/core v0.18.2.
 
 ## See Also
 


### PR DESCRIPTION
### **User description**
## Summary

Update RELEASE.md to reflect the September 2025 releases of all handler modules.

## Changes

Documentation update following today's releases:
- slog v0.8.1 
- handlers/cblog v0.8.1
- handlers/discard v0.6.2
- handlers/filter v0.7.0 (breaking changes)
- handlers/logr v0.1.1
- handlers/logrus v0.7.3
- handlers/zap v0.7.1
- handlers/zerolog v0.6.2

All handlers now use darvaza.org/core v0.18.2.

## Release Notes

### Filter v0.7.0 (Breaking Changes)
- Complete architecture refactoring with two-tier design
- `New()` and `NewNoop()` now return `*Logger` instead of `slog.Logger`
- Removed `FieldOverride`/`FieldsOverride` in favour of `FieldsFilter`
- Added filter hierarchy with sophisticated fallback system

### Other Handlers (Patch Releases)
- Performance optimizations using cached FieldsMap()
- Made Loglet embedding private to control method exposure
- Modernised testing patterns
- Updated dependencies to slog v0.8.1 and core v0.18.2

## Test Plan

- [x] All releases created and tagged
- [x] pkg.go.dev indexing triggered
- [x] GitHub releases published
- [x] Documentation updated


___

### **PR Type**
Documentation


___

### **Description**
- Update version numbers for September 2025 releases

- Reflect all handler modules' latest versions

- Update core dependency to v0.18.2


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["August 2025 versions"] --> B["September 2025 versions"]
  B --> C["Updated core dependency"]
  C --> D["Documentation reflects latest releases"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RELEASE.md</strong><dd><code>Update latest release versions for September</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

RELEASE.md

<ul><li>Updated date from August to September 2025<br> <li> Bumped version numbers for all handler modules<br> <li> Updated core dependency from v0.18.1 to v0.18.2</ul>


</details>


  </td>
  <td><a href="https://github.com/darvaza-proxy/slog/pull/141/files#diff-2b1b69303b927a484e02c7fad9fc87d0d3ff0dc22ae1da0ecd0dc935d922a23c">+12/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated “Latest Releases” to September 2025 with refreshed version tags for the core module and all handlers (including slog, cblog, discard, filter, logr, logrus, zap, zerolog).
  * Bumped shared core dependency to v0.18.2.
  * Header now reads “As of September 2025.”
  * Reaffirmed requirement of Go 1.23+.
  * No changes to public APIs; “See Also” unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->