### PR TITLE
chore(deps): update handlers to slog v0.9.0

### DIFF
--- a/handlers/cblog/go.mod
+++ b/handlers/cblog/go.mod
@@ -2,14 +2,14 @@ module darvaza.org/slog/handlers/cblog
 
 go 1.24.0
 
-replace darvaza.org/slog => ../../
-
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
+
+replace darvaza.org/slog => ../../

--- a/handlers/discard/go.mod
+++ b/handlers/discard/go.mod
@@ -2,14 +2,14 @@ module darvaza.org/slog/handlers/discard
 
 go 1.24.0
 
-replace darvaza.org/slog => ../../
-
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
+
+replace darvaza.org/slog => ../../

--- a/handlers/filter/go.mod
+++ b/handlers/filter/go.mod
@@ -2,14 +2,14 @@ module darvaza.org/slog/handlers/filter
 
 go 1.24.0
 
-replace darvaza.org/slog => ../../
-
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
+
+replace darvaza.org/slog => ../../

--- a/handlers/logr/go.mod
+++ b/handlers/logr/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require github.com/go-logr/logr v1.4.3

--- a/handlers/logrus/go.mod
+++ b/handlers/logrus/go.mod
@@ -2,11 +2,9 @@ module darvaza.org/slog/handlers/logrus
 
 go 1.24.0
 
-replace darvaza.org/slog => ../../
-
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require github.com/sirupsen/logrus v1.9.3
@@ -17,3 +15,5 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
+
+replace darvaza.org/slog => ../../

--- a/handlers/zap/go.mod
+++ b/handlers/zap/go.mod
@@ -2,11 +2,9 @@ module darvaza.org/slog/handlers/zap
 
 go 1.24.0
 
-replace darvaza.org/slog => ../../
-
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require go.uber.org/zap v1.27.0
@@ -17,3 +15,5 @@ require (
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
+
+replace darvaza.org/slog => ../../

--- a/handlers/zerolog/go.mod
+++ b/handlers/zerolog/go.mod
@@ -2,11 +2,9 @@ module darvaza.org/slog/handlers/zerolog
 
 go 1.24.0
 
-replace darvaza.org/slog => ../../
-
 require (
 	darvaza.org/core v0.19.0
-	darvaza.org/slog v0.8.1
+	darvaza.org/slog v0.9.0
 )
 
 require github.com/rs/zerolog v1.34.0
@@ -18,3 +16,5 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 )
+
+replace darvaza.org/slog => ../../


### PR DESCRIPTION
## Summary

- Bump `darvaza.org/slog v0.8.1 → v0.9.0` in the seven handler
  modules (cblog, discard, filter, logr, logrus, zap, zerolog).
- Move `replace darvaza.org/slog => ../../` to the file end in
  the six handlers that carried it near the top, matching the
  existing `logr` shape.

The v0.9.0 release is internal-only — Go 1.24 floor, core
v0.19.0, and a documentation/test modernisation pass. No public
API changes. Full release notes on the tag.

## Test plan

- [ ] CI matrix green across {1.24, 1.25, 1.26} for every handler.
- [ ] Race detection clean.
- [ ] Replace directive still resolves to `../../` so local builds
      track the working tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated core logging dependencies across all handler modules to their latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->