### PR TITLE
feat(zap): add NewReversed to back a zap.Logger with any slog.Logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,7 @@ Each handler is a separate Go module in the `handlers/` directory:
 - **`cblog`**: Channel-based logger for receiving log entries through channels.
 - **`discard`**: No-op logger for testing and optional logging scenarios.
 - **`filter`**: Middleware logger for filtering and transforming log entries.
+- **`logr`**: Bidirectional adapter for the go-logr/logr interface.
 - **`logrus`**: Adapter for the popular logrus logging library.
 - **`zap`**: Adapter for Uber's zap high-performance logger.
 - **`zerolog`**: Adapter for the zerolog JSON logger.
@@ -396,7 +397,7 @@ When updating slog version in handlers:
 
 ```bash
 # Update all handlers to a new slog version
-for handler in cblog discard filter logrus zap zerolog; do
+for handler in cblog discard filter logr logrus zap zerolog; do
   go -C handlers/$handler get darvaza.org/slog@v0.7.0
 done
 
@@ -407,7 +408,7 @@ To update all dependencies in handlers:
 
 ```bash
 # Update all dependencies (use with caution)
-for handler in cblog discard filter logrus zap zerolog; do
+for handler in cblog discard filter logr logrus zap zerolog; do
   go -C handlers/$handler get -u
 done
 ```

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ These handlers allow conversion in both directions - you can use the external
 logging library as a slog backend, OR use slog as a backend for the external
 library:
 
-- **[logr](https://pkg.go.dev/darvaza.org/slog/handlers/logr)**:
+- **[`logr`](https://pkg.go.dev/darvaza.org/slog/handlers/logr)**:
   Full bidirectional adapter for go-logr/logr interface.
   - `logr.Logger` → `slog.Logger` (use logr as slog backend)
   - `slog.Logger` → `logr.Logger` (use slog as logr backend)

--- a/README.md
+++ b/README.md
@@ -264,8 +264,9 @@ library:
   - `logrus.Logger` → `slog.Logger` (use logrus as slog backend)
   - `slog.Logger` → `logrus.Logger` (use slog as logrus backend)
 - **[`zap`](https://pkg.go.dev/darvaza.org/slog/handlers/zap)**:
-  Bidirectional adapter between Uber's zap and slog. Use zap as a slog backend
-  or create zap loggers backed by any slog implementation.
+  Bidirectional adapter between Uber's zap and slog.
+  - `zap.Logger` → `slog.Logger` (use zap as slog backend)
+  - `slog.Logger` → `zap.Logger` (use slog as zap backend)
 
 #### Unidirectional Adapters
 

--- a/handlers/zap/AGENTS.md
+++ b/handlers/zap/AGENTS.md
@@ -38,6 +38,10 @@ repository. For developers and general project information, please refer to
 - Converts zap fields using `MapObjectEncoder`.
 - Maintains field accumulation through `With()` calls.
 - Preserves zap's expectations for Fatal/Panic behaviour.
+- `NewReversed` unwraps zap-backed parents to their underlying
+  `*zap.Logger` (carrying over accumulated fields) and otherwise
+  builds on `NewCore` with level decisions delegated to the parent;
+  optional `zap.Option` values apply either way.
 
 ## Usage Patterns
 
@@ -121,14 +125,14 @@ zapLogger.Info("Request completed",
 
 ## Level Mapping
 
-| slog Level | zap Level |
-|------------|-----------|
-| Debug      | Debug     |
-| Info       | Info      |
-| Warn       | Warn      |
-| Error      | Error     |
-| Fatal      | Fatal     |
-| Panic      | Panic     |
+| slog Level | zap Level    |
+|------------|--------------|
+| Debug      | Debug        |
+| Info       | Info         |
+| Warn       | Warn         |
+| Error      | Error/DPanic |
+| Fatal      | Fatal        |
+| Panic      | Panic        |
 
 ## Performance Considerations
 

--- a/handlers/zap/README.md
+++ b/handlers/zap/README.md
@@ -129,17 +129,18 @@ it now accepts variadic `zap.Option` parameters for customizing the logger.
 
 ## Level Mapping
 
-| slog Level | zap Level    | Behaviour        |
-|------------|--------------|------------------|
-| Debug      | Debug        | Standard mapping |
-| Info       | Info         | Standard mapping |
-| Warn       | Warn         | Standard mapping |
-| Error      | Error        | Standard mapping |
-| Fatal      | Fatal        | Calls os.Exit(1) |
-| Panic      | Panic/DPanic | Calls panic()    |
+| slog Level | zap Level    | Behaviour         |
+|------------|--------------|-------------------|
+| Debug      | Debug        | Standard mapping  |
+| Info       | Info         | Standard mapping  |
+| Warn       | Warn         | Standard mapping  |
+| Error      | Error/DPanic | Standard mapping  |
+| Fatal      | Fatal        | Exits the program |
+| Panic      | Panic        | Panics            |
 
-**Note:** DPanic (Development Panic) maps to slog.Panic and triggers panic()
-behaviour.
+**Note:** DPanic (Development Panic) maps to slog.Error; zap itself panics
+on DPanic entries in development mode, so production DPanic entries are
+logged without panicking, matching native zap.
 
 ## Performance Tips
 

--- a/handlers/zap/README.md
+++ b/handlers/zap/README.md
@@ -94,6 +94,15 @@ zapLogger = zap.New(core,
     zap.AddCaller(),
     zap.AddStacktrace(zap.ErrorLevel),
 )
+
+// Or let the adapter choose the best route. Zap-backed parents are
+// unwrapped to their underlying *zap.Logger, carrying over accumulated
+// fields; any other parent is wrapped with level decisions delegated
+// to it. Optional zap.Option values apply either way.
+zapLogger, err := slogzap.NewReversed(filtered, zap.AddCaller())
+if err != nil {
+    panic(err)
+}
 ```
 
 ## Breaking Changes

--- a/handlers/zap/core.go
+++ b/handlers/zap/core.go
@@ -1,8 +1,6 @@
 package zap
 
 import (
-	"fmt"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -98,22 +96,11 @@ func (c *SlogCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 		logger = logger.WithFields(convertFields(fields))
 	}
 
-	// Log the message
+	// Log the message. Terminal behaviour is not ours to add: the
+	// slog backend exits or panics on Fatal/Panic entries per the
+	// slog contract, and zap's CheckedEntry performs WriteThenFatal
+	// or WriteThenPanic after all cores have written.
 	logger.Print(entry.Message)
-
-	// Handle Fatal and Panic as zap expects
-	switch entry.Level {
-	case zapcore.FatalLevel:
-		// zap expects Fatal to exit
-		c.logger.Fatal().Print("zap fatal exit")
-	case zapcore.PanicLevel, zapcore.DPanicLevel:
-		// zap expects Panic to panic
-		panic(fmt.Sprintf("zap panic: %s", entry.Message))
-	default:
-		// Debug/Info/Warn/Error and any unknown levels need no
-		// post-write action — the message has already been emitted
-		// to the slog backend at the mapped level.
-	}
 
 	return nil
 }

--- a/handlers/zap/core.go
+++ b/handlers/zap/core.go
@@ -86,15 +86,11 @@ func (c *SlogCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 		logger = logger.WithField("caller", entry.Caller.String())
 	}
 
-	// Convert and add accumulated fields from With() calls
-	if len(c.fields) > 0 {
-		logger = logger.WithFields(convertFields(c.fields))
-	}
-
-	// Convert and add fields from this Write call
-	if len(fields) > 0 {
-		logger = logger.WithFields(convertFields(fields))
-	}
+	// Convert and add accumulated fields from With() calls,
+	// then fields from this Write call. convertFields returns
+	// nil when there is nothing to add.
+	logger = logger.WithFields(convertFields(c.fields))
+	logger = logger.WithFields(convertFields(fields))
 
 	// Log the message. Terminal behaviour is not ours to add: the
 	// slog backend exits or panics on Fatal/Panic entries per the

--- a/handlers/zap/core_test.go
+++ b/handlers/zap/core_test.go
@@ -104,25 +104,29 @@ func TestSlogCoreCheck(t *testing.T) {
 
 func TestSlogCoreWrite(t *testing.T) {
 	t.Run("FatalWrite", runTestSlogCoreFatalWrite)
+	t.Run("FatalHook", runTestSlogCoreFatalHook)
+	t.Run("PanicCoreWrite", runTestSlogCorePanicCoreWrite)
 	t.Run("PanicWrite", runTestSlogCorePanicWrite)
+	t.Run("DPanicProduction", runTestSlogCoreDPanicProduction)
+	t.Run("DPanicDevelopment", runTestSlogCoreDPanicDevelopment)
 }
 
 func newMapTestCase(
-	name string, zapLevel zapcore.Level, expectedSlogLevel slog.LogLevel, shouldPanic bool,
+	name string, zapLevel zapcore.Level, expectedSlogLevel slog.LogLevel,
 ) mapTestCase {
 	return mapTestCase{
 		name:              name,
 		zapLevel:          zapLevel,
 		expectedSlogLevel: expectedSlogLevel,
-		shouldPanic:       shouldPanic,
 	}
 }
 
 func mapTestCases() []mapTestCase {
 	return []mapTestCase{
-		newMapTestCase("DPanicLevel", zapcore.DPanicLevel, slog.Panic, true),
-		newMapTestCase("UnknownLevel", zapcore.Level(99), slog.Info, false),
-		newMapTestCase("InvalidLevel", zapcore.InvalidLevel, slog.Info, false),
+		newMapTestCase("PanicLevel", zapcore.PanicLevel, slog.Panic),
+		newMapTestCase("DPanicLevel", zapcore.DPanicLevel, slog.Error),
+		newMapTestCase("UnknownLevel", zapcore.Level(99), slog.Info),
+		newMapTestCase("InvalidLevel", zapcore.InvalidLevel, slog.Info),
 	}
 }
 
@@ -624,71 +628,98 @@ func runTestSlogCoreFatalWrite(t *testing.T) {
 	recorder := mock.NewLogger()
 	zapCore := slogzap.NewCore(recorder, zap.DebugLevel)
 
-	// We can't actually test os.Exit, but we can verify the Fatal log is written
+	// Write only records the entry; the exit belongs to the slog
+	// backend or to zap's CheckedEntry machinery, not to the Core.
 	entry := zapcore.Entry{
 		Level:   zapcore.FatalLevel,
 		Message: "fatal error occurred",
 	}
-
-	// Note: This test cannot verify os.Exit behaviour in unit tests.
-	// The actual Exit call would need to be tested in integration tests.
-	// The Write method will call logger.Fatal() which in our test logger
-	// just records a message with Fatal level
-	err := zapCore.Write(entry, nil)
-	core.AssertNil(t, err, "write error")
+	core.AssertNoError(t, zapCore.Write(entry, nil), "write")
 
 	messages := recorder.GetMessages()
-	core.AssertTrue(t, hasMessage(messages, "fatal error occurred", slog.Fatal),
-		"fatal message found")
-	core.AssertTrue(t, hasMessage(messages, "zap fatal exit", slog.Fatal),
-		"zap fatal exit message")
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, slog.Fatal, messages[0].Level, "level")
+	core.AssertEqual(t, "fatal error occurred", messages[0].Message, "message")
 }
 
-// hasMessage reports whether the recorder captured a message
-// matching both the given text and slog level.
-func hasMessage(messages []mock.Message, text string, level slog.LogLevel) bool {
-	for _, msg := range messages {
-		if msg.Message == text && msg.Level == level {
-			return true
-		}
+// runTestSlogCoreFatalHook verifies the zap layer owns Fatal terminal
+// behaviour; WriteThenPanic substitutes the untestable os.Exit.
+func runTestSlogCoreFatalHook(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	zapLogger := zap.New(slogzap.NewCore(recorder, zap.DebugLevel),
+		zap.WithFatalHook(zapcore.WriteThenPanic))
+
+	core.AssertPanic(t, func() {
+		zapLogger.Fatal("fatal error occurred")
+	}, "fatal error occurred", "fatal hook")
+
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, slog.Fatal, messages[0].Level, "level")
+}
+
+func runTestSlogCorePanicCoreWrite(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	zapCore := slogzap.NewCore(recorder, zap.DebugLevel)
+
+	// A bare Core.Write never panics; like every zapcore.Core it
+	// only writes, and CheckedEntry adds the terminal action.
+	entry := zapcore.Entry{
+		Level:   zapcore.PanicLevel,
+		Message: "panic message",
 	}
-	return false
-}
-
-func runTestPanicLevel(t *testing.T, zapCore zapcore.Core) {
-	t.Helper()
-	core.AssertPanic(t, func() {
-		entry := zapcore.Entry{
-			Level:   zapcore.PanicLevel,
-			Message: "panic message",
-		}
+	core.AssertNoPanic(t, func() {
 		_ = zapCore.Write(entry, nil)
-	}, "zap panic: panic message", "PanicLevel panic")
-}
+	}, "core write")
 
-func runTestDPanicLevel(t *testing.T, zapCore zapcore.Core) {
-	t.Helper()
-	core.AssertPanic(t, func() {
-		entry := zapcore.Entry{
-			Level:   zapcore.DPanicLevel,
-			Message: "development panic",
-		}
-		_ = zapCore.Write(entry, nil)
-	}, "zap panic: development panic", "DPanicLevel panic")
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, slog.Panic, messages[0].Level, "level")
 }
 
 func runTestSlogCorePanicWrite(t *testing.T) {
 	t.Helper()
 	recorder := mock.NewLogger()
-	zapCore := slogzap.NewCore(recorder, zap.DebugLevel)
+	zapLogger := zap.New(slogzap.NewCore(recorder, zap.DebugLevel))
 
-	t.Run("PanicLevel", func(t *testing.T) {
-		runTestPanicLevel(t, zapCore)
-	})
+	core.AssertPanic(t, func() {
+		zapLogger.Panic("panic message")
+	}, "panic message", "zap layer panic")
 
-	t.Run("DPanicLevel", func(t *testing.T) {
-		runTestDPanicLevel(t, zapCore)
-	})
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, slog.Panic, messages[0].Level, "level")
+}
+
+func runTestSlogCoreDPanicProduction(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	zapLogger := zap.New(slogzap.NewCore(recorder, zap.DebugLevel))
+
+	core.AssertNoPanic(t, func() {
+		zapLogger.DPanic("development panic")
+	}, "production DPanic")
+
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, slog.Error, messages[0].Level, "level")
+}
+
+func runTestSlogCoreDPanicDevelopment(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	zapLogger := zap.New(slogzap.NewCore(recorder, zap.DebugLevel),
+		zap.Development())
+
+	core.AssertPanic(t, func() {
+		zapLogger.DPanic("development panic")
+	}, "development panic", "development DPanic")
+
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, slog.Error, messages[0].Level, "level")
 }
 
 func runTestConvertFieldsEmpty(t *testing.T) {
@@ -735,11 +766,11 @@ func runTestZapLoggerInvalidLevel(t *testing.T) {
 }
 
 // mapTestCase represents a test case for zap to slog level mapping
+// through SlogCore.Write.
 type mapTestCase struct {
 	name              string
-	zapLevel          zapcore.Level
 	expectedSlogLevel slog.LogLevel
-	shouldPanic       bool
+	zapLevel          zapcore.Level
 }
 
 func (tc mapTestCase) Name() string {
@@ -751,32 +782,16 @@ func (tc mapTestCase) Test(t *testing.T) {
 	recorder := mock.NewLogger()
 	zapCore := slogzap.NewCore(recorder, zapcore.DebugLevel)
 
-	if tc.shouldPanic {
-		core.AssertPanic(t, func() {
-			entry := zapcore.Entry{
-				Level:   tc.zapLevel,
-				Message: fmt.Sprintf("test level %v", tc.zapLevel),
-			}
-			_ = zapCore.Write(entry, nil)
-		}, nil, "DPanicLevel panic")
-	} else {
-		entry := zapcore.Entry{
-			Level:   tc.zapLevel,
-			Message: fmt.Sprintf("test level %v", tc.zapLevel),
-		}
-
-		recorder.Clear()
-		_ = zapCore.Write(entry, nil)
+	entry := zapcore.Entry{
+		Level:   tc.zapLevel,
+		Message: fmt.Sprintf("test level %v", tc.zapLevel),
 	}
+	core.AssertNoError(t, zapCore.Write(entry, nil), "write")
 
-	// For non-panic levels, check that they were logged at expected level
-	if !tc.shouldPanic {
-		messages := recorder.GetMessages()
-		if len(messages) > 0 {
-			msg := messages[0]
-			core.AssertEqual(t, tc.expectedSlogLevel, msg.Level, "slog level for zap level %v", tc.zapLevel)
-		}
-	}
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	core.AssertEqual(t, tc.expectedSlogLevel, messages[0].Level,
+		"slog level for zap level %v", tc.zapLevel)
 }
 
 // configTestCase represents a test case for configuration testing

--- a/handlers/zap/core_test.go
+++ b/handlers/zap/core_test.go
@@ -21,25 +21,6 @@ var _ core.TestCase = levelTestCase{}
 var _ core.TestCase = mapTestCase{}
 var _ core.TestCase = configTestCase{}
 
-// getFieldValue is a generic helper to safely extract and cast field values
-func getFieldValue[T any](fields map[string]any, key string) (T, bool) {
-	var zero T
-	value, exists := fields[key]
-	if !exists {
-		return zero, false
-	}
-	typed, ok := value.(T)
-	return typed, ok
-}
-
-// assertField is a test helper that checks if a field exists and has the expected value
-func assertField[T comparable](t *testing.T, fields map[string]any, key string, expected T) {
-	t.Helper()
-	actual, ok := getFieldValue[T](fields, key)
-	core.AssertMustTrue(t, ok, "field found")
-	core.AssertEqual(t, expected, actual, "field value")
-}
-
 // assertAnySliceField is a test helper for []any fields (interface slices)
 func assertAnySliceField(t *testing.T, fields map[string]any, key string, expected ...any) {
 	t.Helper()
@@ -192,8 +173,8 @@ func runTestSlogCoreWithFields(t *testing.T) {
 	core.AssertMustEqual(t, 1, len(messages), "log entry count")
 
 	msg := messages[0]
-	assertField(t, msg.Fields, "key1", "value1")
-	assertField(t, msg.Fields, "key2", int64(42))
+	slogtest.AssertField(t, msg, "key1", "value1")
+	slogtest.AssertField(t, msg, "key2", int64(42))
 }
 
 func runTestSlogCoreWith(t *testing.T) {
@@ -217,9 +198,9 @@ func runTestSlogCoreWith(t *testing.T) {
 	core.AssertMustEqual(t, 1, len(messages), "log entry count")
 
 	msg := messages[0]
-	assertField(t, msg.Fields, "persistent", "field")
-	assertField(t, msg.Fields, "request_id", int64(123))
-	assertField(t, msg.Fields, "extra", "value")
+	slogtest.AssertField(t, msg, "persistent", "field")
+	slogtest.AssertField(t, msg, "request_id", int64(123))
+	slogtest.AssertField(t, msg, "extra", "value")
 }
 
 func runTestSlogCoreWithEmpty(t *testing.T) {
@@ -413,10 +394,10 @@ func runTestSlogCoreComplexFields(t *testing.T) {
 
 	msg := messages[0]
 	// Check basic field types
-	assertField(t, msg.Fields, "string", "value")
-	assertField(t, msg.Fields, "int", int64(42))
-	assertField(t, msg.Fields, "float", 3.14)
-	assertField(t, msg.Fields, "bool", true)
+	slogtest.AssertField(t, msg, "string", "value")
+	slogtest.AssertField(t, msg, "int", int64(42))
+	slogtest.AssertField(t, msg, "float", 3.14)
+	slogtest.AssertField(t, msg, "bool", true)
 
 	// Check array fields (zap converts to []any)
 	assertAnySliceField(t, msg.Fields, "strings", "a", "b", "c")
@@ -485,8 +466,8 @@ func runTestBidirectionalSlogToZap(t *testing.T) {
 
 	msg := messages[0]
 	core.AssertEqual(t, "via zap api", msg.Message, "message text")
-	assertField(t, msg.Fields, "path", "slog->zap")
-	assertField(t, msg.Fields, "test_id", int64(1))
+	slogtest.AssertField(t, msg, "path", "slog->zap")
+	slogtest.AssertField(t, msg, "test_id", int64(1))
 }
 
 func runTestBidirectionalZapToSlog(t *testing.T) {
@@ -525,10 +506,10 @@ func runTestBidirectionalCompatibility(t *testing.T) {
 	slogtest.AssertMustMessageCount(t, messages, 1)
 
 	// Verify field types are preserved correctly
-	fields := messages[0].Fields
-	assertField(t, fields, "string", "test")
-	assertField(t, fields, "int", int64(42))
-	assertField(t, fields, "bool", true)
+	msg := messages[0]
+	slogtest.AssertField(t, msg, "string", "test")
+	slogtest.AssertField(t, msg, "int", int64(42))
+	slogtest.AssertField(t, msg, "bool", true)
 }
 
 func runTestSlogCoreConcurrent(t *testing.T) {

--- a/handlers/zap/reverse.go
+++ b/handlers/zap/reverse.go
@@ -1,0 +1,80 @@
+package zap
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"darvaza.org/core"
+	"darvaza.org/slog"
+)
+
+var (
+	_ zapcore.LevelEnabler = (*reverseLevels)(nil)
+)
+
+// errInvalidParent rejects parents [NewReversed] can't build on.
+// It matches [core.ErrInvalid] for errors.Is tests.
+var errInvalidParent = core.QuietWrap(core.ErrInvalid,
+	"invalid parent logger")
+
+// reverseLevels delegates zap level decisions to a parent slog.Logger.
+type reverseLevels struct {
+	l slog.Logger
+}
+
+// Enabled returns true if the parent logger emits entries at the
+// given level.
+func (r *reverseLevels) Enabled(zl zapcore.Level) bool {
+	level, ok := fromZapLevel(zl)
+	if !ok {
+		return false
+	}
+
+	return r.l.WithLevel(level).Enabled()
+}
+
+// NewReversed returns a [zap.Logger] backed by the given [slog.Logger].
+// Entries flow to the parent through [SlogCore], and level decisions
+// are delegated to the parent. When the parent is itself zap-backed,
+// the underlying [zap.Logger] is returned directly, carrying over any
+// fields accumulated on the slog side. Optional [zap.Option] values
+// are applied to the returned logger either way.
+//
+// NewReversed fails with an error matching [core.ErrInvalid] when
+// parent is nil or not backed by a usable logger.
+//
+// Note that wrapped DPanic entries are logged at [slog.Error]; zap's
+// development-mode panic still applies at the [zap.Logger] layer.
+func NewReversed(parent slog.Logger, opts ...zap.Option) (*zap.Logger, error) {
+	switch l := parent.(type) {
+	case *Logger:
+		// unwrap
+		return l.unwrapReversed(opts)
+	default:
+		if core.IsNil(parent) {
+			// parent-less unacceptable
+			return nil, errInvalidParent
+		}
+		// reverse wrapper
+		zc := NewCore(parent, &reverseLevels{l: parent})
+		return zap.New(zc, opts...), nil
+	}
+}
+
+// unwrapReversed returns the wrapped [zap.Logger], applying options
+// and carrying over fields accumulated on the slog side. Pending
+// call-stack context is not carried over.
+func (zpl *Logger) unwrapReversed(opts []zap.Option) (*zap.Logger, error) {
+	if zpl == nil || zpl.logger == nil {
+		return nil, errInvalidParent
+	}
+
+	zl := zpl.logger
+	if len(opts) > 0 {
+		zl = zl.WithOptions(opts...)
+	}
+	if fields := zapFields(zpl.loglet.FieldsMap()); len(fields) > 0 {
+		zl = zl.With(fields...)
+	}
+	return zl, nil
+}

--- a/handlers/zap/reverse_test.go
+++ b/handlers/zap/reverse_test.go
@@ -1,0 +1,282 @@
+package zap_test
+
+// cSpell:words zaptest
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"darvaza.org/core"
+	"darvaza.org/slog"
+	"darvaza.org/slog/handlers/mock"
+	slogzap "darvaza.org/slog/handlers/zap"
+	slogtest "darvaza.org/slog/internal/testing"
+)
+
+// Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = reversedLevelTestCase{}
+var _ core.TestCase = reversedEnabledTestCase{}
+
+func TestNewReversed(t *testing.T) {
+	t.Run("NilParent", runTestNewReversedNilParent)
+	t.Run("TypedNilParent", runTestNewReversedTypedNilParent)
+	t.Run("ForeignTypedNilParent", runTestNewReversedForeignTypedNilParent)
+	t.Run("Unwrap", runTestNewReversedUnwrap)
+	t.Run("UnwrapWithFields", runTestNewReversedUnwrapWithFields)
+	t.Run("UnwrapWithOptions", runTestNewReversedUnwrapWithOptions)
+	t.Run("Forward", runTestNewReversedForward)
+	t.Run("ForwardWithOptions", runTestNewReversedForwardWithOptions)
+	t.Run("ForwardWithParentFields", runTestNewReversedForwardWithParentFields)
+	t.Run("Levels", runTestNewReversedLevels)
+	t.Run("Enabled", runTestNewReversedEnabled)
+}
+
+func runTestNewReversedNilParent(t *testing.T) {
+	t.Helper()
+	zl, err := slogzap.NewReversed(nil)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "nil parent")
+	core.AssertNil(t, zl, "logger")
+}
+
+func runTestNewReversedTypedNilParent(t *testing.T) {
+	t.Helper()
+	var parent *slogzap.Logger
+	zl, err := slogzap.NewReversed(parent)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "typed-nil parent")
+	core.AssertNil(t, zl, "logger")
+}
+
+func runTestNewReversedForeignTypedNilParent(t *testing.T) {
+	t.Helper()
+	var parent *mock.Logger
+	zl, err := slogzap.NewReversed(parent)
+	core.AssertErrorIs(t, err, core.ErrInvalid, "foreign typed-nil parent")
+	core.AssertNil(t, zl, "logger")
+}
+
+func runTestNewReversedUnwrap(t *testing.T) {
+	t.Helper()
+	slogLogger, err := slogzap.New(slogzap.NewDefaultConfig())
+	core.AssertMustNoError(t, err, "create parent")
+
+	parent := core.AssertMustTypeIs[*slogzap.Logger](t, slogLogger, "adaptor type")
+	wrapped, _ := parent.Unwrap()
+
+	zl, err := slogzap.NewReversed(parent)
+	core.AssertMustNoError(t, err, "NewReversed")
+	core.AssertSame(t, wrapped, zl, "unwrapped logger")
+}
+
+func runTestNewReversedUnwrapWithFields(t *testing.T) {
+	t.Helper()
+	obsCore, logs := observer.New(zapcore.DebugLevel)
+	slogLogger, err := slogzap.New(slogzap.NewDefaultConfig(),
+		zap.WrapCore(func(zapcore.Core) zapcore.Core { return obsCore }))
+	core.AssertMustNoError(t, err, "create parent")
+
+	parent := slogLogger.WithField("service", "api")
+	zl, err := slogzap.NewReversed(parent)
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	zl.Info("hello")
+
+	entries := logs.All()
+	core.AssertMustEqual(t, 1, len(entries), "entry count")
+	core.AssertEqual(t, "hello", entries[0].Message, "message")
+	slogtest.AssertFieldValue(t, entries[0].ContextMap(), "service", "api")
+}
+
+// newCountingHook returns a zap hook and a counter it increments on
+// every entry, to verify options reach the returned logger.
+func newCountingHook() (func(zapcore.Entry) error, *int) {
+	count := new(int)
+	hook := func(zapcore.Entry) error {
+		*count++
+		return nil
+	}
+	return hook, count
+}
+
+func runTestNewReversedUnwrapWithOptions(t *testing.T) {
+	t.Helper()
+	obsCore, logs := observer.New(zapcore.DebugLevel)
+	slogLogger, err := slogzap.New(slogzap.NewDefaultConfig(),
+		zap.WrapCore(func(zapcore.Core) zapcore.Core { return obsCore }))
+	core.AssertMustNoError(t, err, "create parent")
+
+	hook, count := newCountingHook()
+	zl, err := slogzap.NewReversed(slogLogger, zap.Hooks(hook))
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	zl.Info("hello")
+	core.AssertEqual(t, 1, *count, "hook count")
+	core.AssertEqual(t, 1, logs.Len(), "entry count")
+}
+
+func runTestNewReversedForward(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	zl, err := slogzap.NewReversed(recorder)
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	zl.Info("forwarded", zap.String("key", "value"))
+
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+
+	msg := messages[0]
+	core.AssertEqual(t, slog.Info, msg.Level, "level")
+	core.AssertEqual(t, "forwarded", msg.Message, "message")
+	slogtest.AssertField(t, msg, "key", "value")
+}
+
+func runTestNewReversedForwardWithOptions(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	hook, count := newCountingHook()
+	zl, err := slogzap.NewReversed(recorder, zap.Hooks(hook))
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	zl.Info("forwarded")
+	core.AssertEqual(t, 1, *count, "hook count")
+	slogtest.AssertMustMessageCount(t, recorder.GetMessages(), 1)
+}
+
+func runTestNewReversedForwardWithParentFields(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLogger()
+	parent := recorder.WithField("service", "api")
+	zl, err := slogzap.NewReversed(parent)
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	zl.Info("forwarded")
+
+	messages := recorder.GetMessages()
+	slogtest.AssertMustMessageCount(t, messages, 1)
+	slogtest.AssertField(t, messages[0], "service", "api")
+}
+
+// reversedLevelTestCase exercises level delegation from the reversed
+// zap logger to a threshold-filtered parent.
+type reversedLevelTestCase struct {
+	logFunc   func(*zap.Logger, string, ...zap.Field)
+	name      string
+	wantCount int
+	threshold slog.LogLevel
+	wantLevel slog.LogLevel
+}
+
+func (tc reversedLevelTestCase) Name() string {
+	return tc.name
+}
+
+func (tc reversedLevelTestCase) Test(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLoggerWithThreshold(tc.threshold)
+	zl, err := slogzap.NewReversed(recorder)
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	tc.logFunc(zl, "test message")
+
+	messages := recorder.GetMessages()
+	core.AssertMustEqual(t, tc.wantCount, len(messages), "message count")
+	if tc.wantCount > 0 {
+		core.AssertEqual(t, tc.wantLevel, messages[0].Level, "level")
+	}
+}
+
+func newReversedLevelTestCase(
+	name string, threshold slog.LogLevel,
+	logFunc func(*zap.Logger, string, ...zap.Field),
+	wantCount int, wantLevel slog.LogLevel,
+) reversedLevelTestCase {
+	return reversedLevelTestCase{
+		name:      name,
+		threshold: threshold,
+		logFunc:   logFunc,
+		wantCount: wantCount,
+		wantLevel: wantLevel,
+	}
+}
+
+func reversedLevelTestCases() []reversedLevelTestCase {
+	return []reversedLevelTestCase{
+		newReversedLevelTestCase("DebugBelowInfoThreshold", slog.Info,
+			(*zap.Logger).Debug, 0, slog.UndefinedLevel),
+		newReversedLevelTestCase("InfoAtInfoThreshold", slog.Info,
+			(*zap.Logger).Info, 1, slog.Info),
+		newReversedLevelTestCase("WarnAboveInfoThreshold", slog.Info,
+			(*zap.Logger).Warn, 1, slog.Warn),
+		newReversedLevelTestCase("InfoBelowErrorThreshold", slog.Error,
+			(*zap.Logger).Info, 0, slog.UndefinedLevel),
+		newReversedLevelTestCase("ErrorAtErrorThreshold", slog.Error,
+			(*zap.Logger).Error, 1, slog.Error),
+		newReversedLevelTestCase("DebugAtDebugThreshold", slog.Debug,
+			(*zap.Logger).Debug, 1, slog.Debug),
+	}
+}
+
+func runTestNewReversedLevels(t *testing.T) {
+	t.Helper()
+	core.RunTestCases(t, reversedLevelTestCases())
+}
+
+// reversedEnabledTestCase probes the reversed logger's level enabler
+// directly, including zap levels with no slog equivalent.
+type reversedEnabledTestCase struct {
+	name      string
+	threshold slog.LogLevel
+	zapLevel  zapcore.Level
+	want      bool
+}
+
+func (tc reversedEnabledTestCase) Name() string {
+	return tc.name
+}
+
+func (tc reversedEnabledTestCase) Test(t *testing.T) {
+	t.Helper()
+	recorder := mock.NewLoggerWithThreshold(tc.threshold)
+	zl, err := slogzap.NewReversed(recorder)
+	core.AssertMustNoError(t, err, "NewReversed")
+
+	core.AssertEqual(t, tc.want, zl.Core().Enabled(tc.zapLevel), "enabled")
+}
+
+func newReversedEnabledTestCase(
+	name string, threshold slog.LogLevel, zapLevel zapcore.Level, want bool,
+) reversedEnabledTestCase {
+	return reversedEnabledTestCase{
+		name:      name,
+		threshold: threshold,
+		zapLevel:  zapLevel,
+		want:      want,
+	}
+}
+
+func reversedEnabledTestCases() []reversedEnabledTestCase {
+	return []reversedEnabledTestCase{
+		newReversedEnabledTestCase("InvalidLevel", slog.Debug,
+			zapcore.InvalidLevel, false),
+		newReversedEnabledTestCase("OutOfRangeLevel", slog.Debug,
+			zapcore.Level(99), false),
+		newReversedEnabledTestCase("BelowRangeLevel", slog.Debug,
+			zapcore.Level(-2), false),
+		newReversedEnabledTestCase("DPanicAtErrorThreshold", slog.Error,
+			zapcore.DPanicLevel, true),
+		newReversedEnabledTestCase("DPanicBelowFatalThreshold", slog.Fatal,
+			zapcore.DPanicLevel, false),
+		newReversedEnabledTestCase("DebugBelowInfoThreshold", slog.Info,
+			zapcore.DebugLevel, false),
+		newReversedEnabledTestCase("InfoAtInfoThreshold", slog.Info,
+			zapcore.InfoLevel, true),
+	}
+}
+
+func runTestNewReversedEnabled(t *testing.T) {
+	t.Helper()
+	core.RunTestCases(t, reversedEnabledTestCases())
+}

--- a/handlers/zap/utils.go
+++ b/handlers/zap/utils.go
@@ -50,6 +50,35 @@ func mapFromZapLevel(level zapcore.Level) slog.LogLevel {
 	}
 }
 
+// toZapLevel maps slog levels to zap levels, rejecting values outside
+// the range slog defines.
+func toZapLevel(level slog.LogLevel) (zapcore.Level, bool) {
+	zl := mapToZapLevel(level)
+	return zl, zl != zapcore.InvalidLevel
+}
+
+// fromZapLevel maps zap levels to slog levels, rejecting values
+// outside the range zap defines.
+func fromZapLevel(level zapcore.Level) (slog.LogLevel, bool) {
+	if level < zapcore.DebugLevel || level > zapcore.FatalLevel {
+		return slog.UndefinedLevel, false
+	}
+	return mapFromZapLevel(level), true
+}
+
+// zapFields converts a slog fields map to zap fields.
+func zapFields(m map[string]any) []zap.Field {
+	if len(m) == 0 {
+		return nil
+	}
+
+	fields := make([]zap.Field, 0, len(m))
+	for k, v := range m {
+		fields = append(fields, zap.Any(k, v))
+	}
+	return fields
+}
+
 // getConfigLevel extracts the current log level from a zap config
 func getConfigLevel(cfg *zap.Config) slog.LogLevel {
 	if cfg == nil || cfg.Level == (zap.AtomicLevel{}) {

--- a/handlers/zap/utils.go
+++ b/handlers/zap/utils.go
@@ -34,9 +34,12 @@ func mapFromZapLevel(level zapcore.Level) slog.LogLevel {
 		return slog.Debug
 	case zapcore.WarnLevel:
 		return slog.Warn
-	case zapcore.ErrorLevel:
+	case zapcore.ErrorLevel, zapcore.DPanicLevel:
+		// DPanic only panics in development mode, which the
+		// zap.Logger layer handles; slog has no conditional
+		// equivalent, so use the strongest non-terminal level.
 		return slog.Error
-	case zapcore.DPanicLevel, zapcore.PanicLevel:
+	case zapcore.PanicLevel:
 		return slog.Panic
 	case zapcore.FatalLevel:
 		return slog.Fatal

--- a/handlers/zap/utils_test.go
+++ b/handlers/zap/utils_test.go
@@ -87,7 +87,7 @@ func mapFromZapLevelTestCases() []mapFromZapLevelTestCase {
 		newMapFromZapLevelTestCase("Error", zapcore.ErrorLevel, slog.Error),
 		newMapFromZapLevelTestCase("Fatal", zapcore.FatalLevel, slog.Fatal),
 		newMapFromZapLevelTestCase("Panic", zapcore.PanicLevel, slog.Panic),
-		newMapFromZapLevelTestCase("DPanic", zapcore.DPanicLevel, slog.Panic),
+		newMapFromZapLevelTestCase("DPanic", zapcore.DPanicLevel, slog.Error),
 		newMapFromZapLevelTestCase("Invalid", zapcore.InvalidLevel, slog.Info),
 		newMapFromZapLevelTestCase("Unknown", zapcore.Level(99), slog.Info),
 	}

--- a/handlers/zap/zap.go
+++ b/handlers/zap/zap.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"darvaza.org/core"
 	"darvaza.org/slog"
 	"darvaza.org/slog/internal"
 )
@@ -83,23 +84,14 @@ func (zpl *Logger) Printf(format string, args ...any) {
 
 func (zpl *Logger) logMessage(msg string) {
 	msg = strings.TrimSpace(msg)
-	level := mapToZapLevel(zpl.loglet.Level())
-	if level == zapcore.InvalidLevel {
-		zpl.Panic().WithStack(1).Printf("slog: invalid log level %v", zpl.loglet.Level())
-	}
+	// unreachable: the Print methods gate on Enabled(), which
+	// panics or returns false on invalid levels.
+	level := core.MustOK(toZapLevel(zpl.loglet.Level()))
 
 	// Check if we can log at this level
 	if ce := zpl.logger.Check(level, msg); ce != nil {
 		// Add fields from Loglet chain
-		if fieldsMap := zpl.loglet.FieldsMap(); len(fieldsMap) > 0 {
-			fields := make([]zap.Field, 0, len(fieldsMap))
-			for k, v := range fieldsMap {
-				fields = append(fields, zap.Any(k, v))
-			}
-			ce.Write(fields...)
-		} else {
-			ce.Write()
-		}
+		ce.Write(zapFields(zpl.loglet.FieldsMap())...)
 	}
 }
 

--- a/internal/testing/README.md
+++ b/internal/testing/README.md
@@ -289,6 +289,8 @@ func TestAdapterWithLevelFiltering(t *testing.T) {
 - `AssertMessage(t, msg, level, text)` - Verifies message level and text
 - `AssertField(t, msg, key, value)` - Verifies a field exists with expected
   value
+- `AssertFieldValue(t, fields, key, value)` - Verifies a field exists with
+  expected value in a bare fields map
 - `AssertNoField(t, msg, key)` - Verifies a field does not exist
 - `AssertMessageCount(t, messages, count)` - Verifies the number of messages
 

--- a/internal/testing/doc.go
+++ b/internal/testing/doc.go
@@ -33,6 +33,8 @@
 //
 //   - AssertMessage/AssertMustMessage: Verify log level and message text
 //   - AssertField/AssertMustField: Verify field existence and value
+//   - AssertFieldValue/AssertMustFieldValue: Verify field existence and value
+//     on a bare fields map
 //   - AssertNoField/AssertMustNoField: Verify field absence
 //   - AssertMessageCount/AssertMustMessageCount: Verify message count with debugging output
 //

--- a/internal/testing/helpers.go
+++ b/internal/testing/helpers.go
@@ -66,11 +66,7 @@ func AssertMustMessage(t core.T, msg Message, level slog.LogLevel, text string) 
 // Returns true if the field exists and has the expected value, false otherwise.
 func AssertField(t core.T, msg Message, key string, value any) bool {
 	t.Helper()
-	got, exists := msg.Fields[key]
-	if !core.AssertTrue(t, exists, "field %q exists", key) {
-		return false
-	}
-	return core.AssertEqual(t, value, got, "field %q value", key)
+	return AssertFieldValue(t, msg.Fields, key, value)
 }
 
 // AssertMustField verifies that a message contains a field with the expected value.
@@ -78,6 +74,29 @@ func AssertField(t core.T, msg Message, key string, value any) bool {
 func AssertMustField(t core.T, msg Message, key string, value any) {
 	t.Helper()
 	if !AssertField(t, msg, key, value) {
+		t.FailNow()
+	}
+}
+
+// AssertFieldValue verifies that a fields map contains a field with the
+// expected value. It serves call sites holding a bare fields map, such as
+// entries captured outside the [Message] recorder.
+// Returns true if the field exists and has the expected value, false otherwise.
+func AssertFieldValue(t core.T, fields map[string]any, key string, value any) bool {
+	t.Helper()
+	got, exists := fields[key]
+	if !core.AssertTrue(t, exists, "field %q exists", key) {
+		return false
+	}
+	return core.AssertEqual(t, value, got, "field %q value", key)
+}
+
+// AssertMustFieldValue verifies that a fields map contains a field with the
+// expected value.
+// If the assertion fails, the test is terminated immediately with t.FailNow().
+func AssertMustFieldValue(t core.T, fields map[string]any, key string, value any) {
+	t.Helper()
+	if !AssertFieldValue(t, fields, key, value) {
 		t.FailNow()
 	}
 }

--- a/internal/testing/helpers_test.go
+++ b/internal/testing/helpers_test.go
@@ -362,6 +362,69 @@ func TestAssertNoField(t *testing.T) {
 }
 
 // Compile-time verification that test case types implement TestCase interface
+var _ core.TestCase = assertFieldValueTestCase{}
+
+type assertFieldValueTestCase struct {
+	value      any
+	fields     map[string]any
+	key        string
+	name       string
+	expectPass bool
+}
+
+func (tc assertFieldValueTestCase) Name() string {
+	return tc.name
+}
+
+func (tc assertFieldValueTestCase) Test(t *testing.T) {
+	t.Helper()
+
+	// Use MockT to test assertion function without failing the build
+	mock := &core.MockT{}
+	result := AssertFieldValue(mock, tc.fields, tc.key, tc.value)
+
+	core.AssertEqual(t, tc.expectPass, result, "result")
+}
+
+func newAssertFieldValueTestCase(name string, fields map[string]any,
+	key string, value any, expectPass bool) assertFieldValueTestCase {
+	return assertFieldValueTestCase{
+		name:       name,
+		fields:     fields,
+		key:        key,
+		value:      value,
+		expectPass: expectPass,
+	}
+}
+
+func assertFieldValueTestCases() []assertFieldValueTestCase {
+	return []assertFieldValueTestCase{
+		newAssertFieldValueTestCase("field with expected value",
+			map[string]any{"existing": "value"}, "existing", "value",
+			true),
+		newAssertFieldValueTestCase("field with wrong value",
+			map[string]any{"existing": "value"}, "existing", "wrong",
+			false),
+		newAssertFieldValueTestCase("field does not exist",
+			map[string]any{"existing": "value"}, "non-existent", "value",
+			false),
+		newAssertFieldValueTestCase("empty fields map",
+			map[string]any{}, "someKey", "value",
+			false),
+		newAssertFieldValueTestCase("nil fields map",
+			nil, "someKey", "value",
+			false),
+		newAssertFieldValueTestCase("field with nil value",
+			map[string]any{"nilField": nil}, "nilField", nil,
+			true),
+	}
+}
+
+func TestAssertFieldValue(t *testing.T) {
+	core.RunTestCases(t, assertFieldValueTestCases())
+}
+
+// Compile-time verification that test case types implement TestCase interface
 var _ core.TestCase = runWithLoggerFactoryTestCase{}
 
 type runWithLoggerFactoryTestCase struct {
@@ -461,6 +524,27 @@ func runTestAssertMustFieldFailure(t *testing.T) {
 	mock := &core.MockT{}
 	mock.Run("subtest", func(subT core.T) {
 		AssertMustField(subT, msg, "missing", "value")
+	})
+	core.AssertTrue(t, mock.Failed(), "should have failed")
+}
+
+func TestAssertMustFieldValue(t *testing.T) {
+	t.Run("success case", runTestAssertMustFieldValueSuccess)
+	t.Run("failure case", runTestAssertMustFieldValueFailure)
+}
+
+func runTestAssertMustFieldValueSuccess(t *testing.T) {
+	t.Helper()
+	fields := map[string]any{"existing": "value"}
+	AssertMustFieldValue(t, fields, "existing", "value")
+}
+
+func runTestAssertMustFieldValueFailure(t *testing.T) {
+	t.Helper()
+	fields := map[string]any{"existing": "value"}
+	mock := &core.MockT{}
+	mock.Run("subtest", func(subT core.T) {
+		AssertMustFieldValue(subT, fields, "missing", "value")
 	})
 	core.AssertTrue(t, mock.Failed(), "should have failed")
 }


### PR DESCRIPTION
## Summary

Adds `NewReversed` to `handlers/zap`, completing the bidirectional bridge:
you can now back a `*zap.Logger` with any `slog.Logger`, the mirror of the
existing zap-as-slog adaptor. Also corrects the zap Core's Fatal/Panic
handling to match the zapcore contract, and promotes a couple of
field-assertion helpers into the shared test module.

## What changed

- **`feat(zap): add NewReversed to back a zap.Logger with any slog.Logger`**
  — `NewReversed(parent slog.Logger, opts ...zap.Option) (*zap.Logger, error)`
  routes a `*zap.Logger` through the given `slog.Logger`, delegating level
  decisions to the parent. Zap-backed parents are unwrapped to their
  underlying `*zap.Logger` (carrying over accumulated fields); other parents
  wrap via `NewCore`; nil or parent-less loggers are rejected with an error
  matching `core.ErrInvalid`. `toZapLevel`/`fromZapLevel`/`zapFields` are
  extracted so the wrapper and `logMessage` share level and field
  conversion. Documented in the package and root READMEs and the AGENTS
  notes.

- **`fix(zap): leave terminal behaviour out of SlogCore.Write`**
  — A `zapcore.Core` only writes; zap's `CheckedEntry` performs
  `WriteThenFatal`/`WriteThenPanic` after all cores have written, and
  conforming slog backends already exit or panic on Fatal/Panic. The extra
  "zap fatal exit" entry and the unconditional panic in `Write` duplicated
  both layers and pre-empted Tee siblings. DPanic now maps to `slog.Error`
  rather than `slog.Panic`: DPanic only panics in development mode, which the
  `zap.Logger` layer handles itself, so production DPanic entries log without
  panicking, matching native zap.

- **`test: add map-based field assertions to internal/testing`**
  — `AssertFieldValue`/`AssertMustFieldValue` cover call sites holding a bare
  fields map (e.g. entries captured outside the Message recorder);
  `AssertField` is rebased on the new helper. The zap handler's local
  `assertField` is replaced with `slogtest.AssertField`.

- **`docs: add logr to root handler lists`**
  — `AGENTS.md` omitted logr from the handler-module list and the
  dependency-update loops; `README.md` now formats the logr link like the
  other handler entries.

## Testing

- `make tidy` (go vet + golangci-lint + revive + markdownlint + CSpell)
- `make test`, `make race-zap`, `make race-root`
- zap self-coverage 100.0%; the new `internal/testing` helpers each 100%
  covered
- CI green on the branch head (Build, Test, Race Detection, Codecov)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `NewReversed` for the zap handler, enabling creation of zap loggers backed by slog loggers with field propagation support.

* **Improvements**
  * Updated zap level mapping behavior; DPanic now maps to Error level instead of Panic.
  * Streamlined core logging architecture.

* **Documentation**
  * Enhanced handler documentation with new usage examples and revised level mapping tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->