### PR TITLE
chore(deps): update handlers to slog v0.9.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -356,19 +356,18 @@ For future automation:
 
 ## Latest Releases
 
-### As of September 2025
+### As of June 2026
 
-- **slog**: v0.8.1 (Go 1.23 or later required).
-- **handlers/cblog**: v0.8.1.
-- **handlers/discard**: v0.6.2.
-- **handlers/filter**: v0.7.0.
-  - Breaking changes; see handlers/filter/README.md.
-- **handlers/logr**: v0.1.1.
-- **handlers/logrus**: v0.7.3.
-- **handlers/zap**: v0.7.1.
-- **handlers/zerolog**: v0.6.2.
+- **slog**: v0.9.1 (Go 1.24 or later required).
+- **handlers/cblog**: v0.9.1.
+- **handlers/discard**: v0.7.1.
+- **handlers/filter**: v0.8.1.
+- **handlers/logr**: v0.2.1.
+- **handlers/logrus**: v0.8.1.
+- **handlers/zap**: v0.9.0.
+- **handlers/zerolog**: v0.7.1.
 
-All modules require Go 1.23 or later and use darvaza.org/core v0.18.2.
+All modules require Go 1.24 or later and use darvaza.org/core v0.19.1.
 
 ## See Also
 

--- a/handlers/cblog/go.mod
+++ b/handlers/cblog/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require (

--- a/handlers/discard/go.mod
+++ b/handlers/discard/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require (

--- a/handlers/filter/go.mod
+++ b/handlers/filter/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require (

--- a/handlers/logr/go.mod
+++ b/handlers/logr/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require github.com/go-logr/logr v1.4.3

--- a/handlers/logrus/go.mod
+++ b/handlers/logrus/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require github.com/sirupsen/logrus v1.9.4

--- a/handlers/zap/go.mod
+++ b/handlers/zap/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require go.uber.org/zap v1.28.0

--- a/handlers/zerolog/go.mod
+++ b/handlers/zerolog/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	darvaza.org/core v0.19.1
-	darvaza.org/slog v0.9.0
+	darvaza.org/slog v0.9.1
 )
 
 require github.com/rs/zerolog v1.35.1


### PR DESCRIPTION
## Summary

Release prep following the `darvaza.org/slog v0.9.1` tag: propagates the new
slog version to every handler module and refreshes the release snapshot ahead
of the coordinated handler tags.

## What changed

- **`chore(deps): update handlers to slog v0.9.1`**
  - Bumps `darvaza.org/slog v0.9.0 → v0.9.1` across all seven handler modules
    (cblog, discard, filter, logr, logrus, zap, zerolog). The
    `replace darvaza.org/slog => ../../` directives stay in place for local
    development.
  - Refreshes the RELEASE.md "Latest Releases" snapshot with the next module
    versions, `darvaza.org/core v0.19.1`, and the Go 1.24 floor.

## Planned release versions

| module | next |
|--------|------|
| slog | v0.9.1 (tagged) |
| handlers/cblog | v0.9.1 |
| handlers/discard | v0.7.1 |
| handlers/filter | v0.8.1 |
| handlers/logr | v0.2.1 |
| handlers/logrus | v0.8.1 |
| handlers/zap | **v0.9.0** (minor — gains `NewReversed`) |
| handlers/zerolog | v0.7.1 |

All handlers but zap are dep-bump-only patches; zap takes a minor for the new
`NewReversed` entry point. Handler tags are cut after this merges.

## Testing

- `make TMPDIR=$PWD/.tmp all race coverage` — green across all modules (build,
  tidy, CSpell 0 issues, shellcheck, race clean, coverage unchanged from
  baseline; zap 100.0%)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Go version requirement from 1.23+ to 1.24+
  * Updated internal module dependencies to latest stable versions for enhanced stability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->