### PR TITLE
build: prune .srclight and .claude from file walks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.html
 *.test
 # Build and temporary files
 .tmp
+.srclight/

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ DLX = true
 endif
 endif
 
-FIND_FILES_PRUNE_RULES ?= -name vendor -o -name .git -o -name node_modules -o -name .tmp
+FIND_FILES_PRUNE_RULES ?= -name vendor -o -name .git -o -name node_modules -o -name .tmp -o -name .srclight -o -name .claude
 FIND_FILES_PRUNE_ARGS ?= \( $(FIND_FILES_PRUNE_RULES) \) -prune
 FIND_FILES_GO_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.go'
 FIND_FILES_MARKDOWN_ARGS ?= $(FIND_FILES_PRUNE_ARGS) -o -name '*.md'

--- a/internal/build/fix_whitespace.sh
+++ b/internal/build/fix_whitespace.sh
@@ -114,7 +114,7 @@ run_find() {
 	# Wrap user conditions in parentheses if they exist
 	[ $# -eq 0 ] || set -- \( "$@" \)
 	# combine auto-pruning and user conditions
-	set -- \( -type d \( -name .git -o -name .tmp -o -name node_modules \) \) -prune -o "$@" -type f
+	set -- \( -type d \( -name .git -o -name .tmp -o -name node_modules -o -name .srclight -o -name .claude \) \) -prune -o "$@" -type f
 	# combine escaped paths with find options
 	eval "set -- ${paths:-.} \"\$@\""
 


### PR DESCRIPTION
## build: prune `.srclight` and `.claude` from file walks

### Why

`make tidy` runs the whitespace fixer across the tree, and the fixer's
file walk (along with make's own `FIND_FILES_*` rules) descended into
`.srclight/` — the on-disk home of the srclight semantic index. That
directory holds `index.db`, a binary SQLite file. Rewriting it as if it
were source text corrupts the index, forcing a full reindex. `.claude/`
(Claude Code session data) was walked for the same reason, wasting work
on files no source rule should ever touch.

### What changed

- `Makefile` — add `.srclight` and `.claude` to `FIND_FILES_PRUNE_RULES`.
- `internal/build/fix_whitespace.sh` — add both to the fixer's own
  prune set, so it never descends regardless of how it is invoked.
- `.gitignore` — ignore `.srclight/` so the index never enters the tree.

### Scope

Build-tooling only; no library or runtime code is touched. The change
is part of the shared darvaza.org build system and lands identically
across the sibling repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository cleanup and file-scanning rules to skip additional local tool directories (including hidden workspace-related folders) during formatting and other maintenance tasks.
  * Improved whitespace-fixing tooling by pruning these extra directories from its auto-generated search scope.
  * Added an ignore rule so the local `.srclight/` directory is less likely to be picked up by repo tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->